### PR TITLE
fix(systemd): Remove superflous systemd directive

### DIFF
--- a/lib/systemd/certhub-cert-expiry@.service
+++ b/lib/systemd/certhub-cert-expiry@.service
@@ -14,7 +14,5 @@ ExecStart=/usr/bin/env \
     echo ${CERTHUB_CERT_EXPIRY_MESSAGE}
 
 SyslogIdentifier=certhub-cert-expiry
-StandardOutput=syslog
-StandardError=syslog
 
 PrivateTmp=true

--- a/lib/systemd/certhub-cert-export@.service
+++ b/lib/systemd/certhub-cert-export@.service
@@ -10,7 +10,5 @@ ExecStart=/usr/bin/env \
     rsync $CERTHUB_CERT_EXPORT_RSYNC_ARGS ${CERTHUB_CERT_EXPORT_SRC} ${CERTHUB_CERT_EXPORT_DEST}
 
 SyslogIdentifier=certhub-cert-export
-StandardOutput=syslog
-StandardError=syslog
 
 PrivateTmp=true

--- a/lib/systemd/certhub-cert-reload@.service
+++ b/lib/systemd/certhub-cert-reload@.service
@@ -9,5 +9,3 @@ ExecStart=/usr/bin/env \
     systemctl ${CERTHUB_CERT_RELOAD_COMMAND} {}
 
 SyslogIdentifier=certhub-cert-reload
-StandardOutput=syslog
-StandardError=syslog

--- a/lib/systemd/certhub-cert-send@.service
+++ b/lib/systemd/certhub-cert-send@.service
@@ -9,5 +9,3 @@ ExecStart=/usr/bin/env \
     certhub-send-file ${CERTHUB_CERT_SEND_SRC} $CERTHUB_CERT_SEND_COMMAND
 
 SyslogIdentifier=certhub-cert-send
-StandardOutput=syslog
-StandardError=syslog

--- a/lib/systemd/certhub-certbot-run@.service
+++ b/lib/systemd/certhub-certbot-run@.service
@@ -15,7 +15,5 @@ ExecStart=/usr/bin/env \
     certbot $CERTHUB_CERTBOT_ARGS --config $CERTHUB_CERTBOT_CONFIG
 
 SyslogIdentifier=certhub-certbot-run
-StandardOutput=syslog
-StandardError=syslog
 
 PrivateTmp=true

--- a/lib/systemd/certhub-dehydrated-run@.service
+++ b/lib/systemd/certhub-dehydrated-run@.service
@@ -15,7 +15,5 @@ ExecStart=/usr/bin/env \
     dehydrated $CERTHUB_DEHYDRATED_ARGS --config $CERTHUB_DEHYDRATED_CONFIG
 
 SyslogIdentifier=certhub-dehydrated-run
-StandardOutput=syslog
-StandardError=syslog
 
 PrivateTmp=true

--- a/lib/systemd/certhub-lego-run@.service
+++ b/lib/systemd/certhub-lego-run@.service
@@ -14,7 +14,5 @@ ExecStart=/usr/bin/env \
     lego $CERTHUB_LEGO_CHALLENGE_ARGS $CERTHUB_LEGO_ARGS
 
 SyslogIdentifier=certhub-lego-run
-StandardOutput=syslog
-StandardError=syslog
 
 PrivateTmp=true

--- a/lib/systemd/certhub-repo-push@.service
+++ b/lib/systemd/certhub-repo-push@.service
@@ -9,7 +9,5 @@ ExecStart=/usr/bin/env \
     git --git-dir=${CERTHUB_REPO} push $CERTHUB_REPO_PUSH_ARGS ${CERTHUB_REPO_PUSH_REMOTE} $CERTHUB_REPO_PUSH_REFSPEC
 
 SyslogIdentifier=certhub-repo-push
-StandardOutput=syslog
-StandardError=syslog
 
 PrivateTmp=true


### PR DESCRIPTION
The syslog value for `StandardError` and `StandardError` systemd
directives is deprecated. In fact, certhub units simply should rely on
the default which is `journal` for `StandardOutput` and `inherit` for
`StandardError`.