### PR TITLE
feat(bin): Replace xargs by command shell built-in

### DIFF
--- a/bin/certhub-certbot-run
+++ b/bin/certhub-certbot-run
@@ -10,7 +10,6 @@ ECHO=/bin/echo
 MKTEMP=/bin/mktemp
 MV=/bin/mv
 RM=/bin/rm
-XARGS=/usr/bin/xargs
 
 # Print usage message and exit.
 usage() {
@@ -24,11 +23,11 @@ certhub_certbot_run() {
     CSR_PATH="${3}"
     shift 3
 
-    ${ECHO} certonly \
+    command "${@}" certonly \
         --csr "${CSR_PATH}" \
         --cert-path "${WORKDIR}/cert.pem" \
         --chain-path "${WORKDIR}/chain.pem" \
-        --fullchain-path "${WORKDIR}/fullchain.pem" | ${XARGS} "${@}"
+        --fullchain-path "${WORKDIR}/fullchain.pem"
 
     ${MV} "${WORKDIR}/fullchain.pem" "${FC_PATH}"
 }

--- a/bin/certhub-dehydrated-run
+++ b/bin/certhub-dehydrated-run
@@ -10,7 +10,6 @@ ECHO=/bin/echo
 MKTEMP=/bin/mktemp
 MV=/bin/mv
 RM=/bin/rm
-XARGS=/usr/bin/xargs
 
 # Print usage message and exit.
 usage() {
@@ -24,8 +23,8 @@ certhub_dehydrated_run() {
     CSR_PATH="${3}"
     shift 3
 
-    ${ECHO} --full-chain \
-        --signcsr "${CSR_PATH}" | ${XARGS} "${@}" > "${WORKDIR}/fullchain.pem"
+    command "${@}" --full-chain \
+        --signcsr "${CSR_PATH}" > "${WORKDIR}/fullchain.pem"
 
     ${MV} "${WORKDIR}/fullchain.pem" "${FC_PATH}"
 }

--- a/bin/certhub-lego-run
+++ b/bin/certhub-lego-run
@@ -12,7 +12,6 @@ MKDIR=/bin/mkdir
 MKTEMP=/bin/mktemp
 MV=/bin/mv
 RM=/bin/rm
-XARGS=/usr/bin/xargs
 
 # Print usage message and exit.
 usage() {
@@ -37,11 +36,11 @@ certhub_lego_run() {
     OUTFILEBASE=$(${BASENAME} "${WORKDIR}")/fullchain
     shift 3
 
-    ${ECHO} \
+    command "${@}" \
         --csr "${CSR_PATH}" \
         --filename "${OUTFILEBASE}" \
         --path "${LEGO_DIR}" \
-        run | ${XARGS} "${@}"
+        run
 
     ${MV} "${OUTFILEABS}" "${FC_PATH}"
 }


### PR DESCRIPTION
Certhub used to use xargs in various places in order to prevent that
shell functions were executed instead of a binary. However, this is
exactly the purpose of the shell built-in `command`.

Thus, let's use `command` in place of `xargs` where possible.